### PR TITLE
Add upload_csv route

### DIFF
--- a/dune_client/base_client.py
+++ b/dune_client/base_client.py
@@ -9,7 +9,6 @@ import logging.config
 from typing import Dict
 
 
-# pylint: disable=too-few-public-methods
 class BaseDuneClient:
     """
     A Base Client for Dune which sets up default values

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -374,3 +374,23 @@ class DuneClient(DuneInterface, BaseDuneClient):
         """
         response_json = self._post(route=f"/query/{query_id}/unprivate")
         assert not self.get_query(int(response_json["query_id"])).meta.is_private
+
+    def upload_csv(self, table_name: str, data: str, description: str = "") -> bool:
+        """
+        https://dune.com/docs/api/api-reference/upload-data/?h=data+upload#endpoint
+        The write API allows you to upload any .csv file into Dune. The only limitations are:
+
+        - File has to be < 200 MB
+        - Column names in the table can't start with a special character or digits.
+
+        Below are the specifics of how to work with the API.
+        """
+        response_json = self._post(
+            route="/table/upload/csv",
+            params={
+                "table_name": table_name,
+                "description": description,
+                "data": data,
+            },
+        )
+        return bool(response_json["success"])

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -393,4 +393,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
                 "data": data,
             },
         )
-        return bool(response_json["success"])
+        try:
+            return bool(response_json["success"])
+        except KeyError as err:
+            raise DuneError(response_json, "upload_csv response", err) from err

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -178,7 +178,7 @@ class TestDuneClient(unittest.TestCase):
         client = DuneClient(self.valid_api_key)
         self.assertEqual(
             client.upload_csv(
-                table_name="bh2smith-test",
+                table_name="test",
                 description="best data",
                 data="column1,column2\nvalue1,value2\nvalue3,value4",
             ),

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -156,7 +156,6 @@ class TestDuneClient(unittest.TestCase):
 
     def test_invalid_job_id_error(self):
         dune = DuneClient(self.valid_api_key)
-
         with self.assertRaises(DuneError) as err:
             dune.get_status("Wonky Job ID")
         self.assertEqual(
@@ -174,6 +173,28 @@ class TestDuneClient(unittest.TestCase):
         dune = DuneClient(self.valid_api_key)
         results = dune.get_latest_result(self.query.query_id).get_rows()
         self.assertGreater(len(results), 0)
+
+    def test_upload_csv_success(self):
+        client = DuneClient(self.valid_api_key)
+        self.assertEqual(
+            client.upload_csv(
+                table_name="bh2smith-test",
+                description="best data",
+                data="column1,column2\nvalue1,value2\nvalue3,value4",
+            ),
+            True,
+        )
+
+    def test_upload_csv_fail(self):
+        client = DuneClient(self.valid_api_key)
+        self.assertEqual(
+            client.upload_csv(
+                table_name="addresses",
+                description="should not be able to overwrite existing table that I don't own!",
+                data="column1,column2\nvalue1,value2\nvalue3,value4",
+            ),
+            False,
+        )
 
 
 @unittest.skip("This is an enterprise only endpoint that can no longer be tested.")

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -185,17 +185,6 @@ class TestDuneClient(unittest.TestCase):
             True,
         )
 
-    def test_upload_csv_fail(self):
-        client = DuneClient(self.valid_api_key)
-        self.assertEqual(
-            client.upload_csv(
-                table_name="addresses",
-                description="should not be able to overwrite existing table that I don't own!",
-                data="column1,column2\nvalue1,value2\nvalue3,value4",
-            ),
-            False,
-        )
-
 
 @unittest.skip("This is an enterprise only endpoint that can no longer be tested.")
 class TestCRUDOps(unittest.TestCase):

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -178,7 +178,7 @@ class TestDuneClient(unittest.TestCase):
         client = DuneClient(self.valid_api_key)
         self.assertEqual(
             client.upload_csv(
-                table_name="test",
+                table_name="e2e-test",
                 description="best data",
                 data="column1,column2\nvalue1,value2\nvalue3,value4",
             ),


### PR DESCRIPTION
This PR adds CSV upload functionality to the API client.

Unfortunately, it appears, I have the ability to completely overwrite other users tables... Not sure if this was intended. cc @msf 


Tests are failing, because I assumed I would get a False success response when trying to overwrite someone else's table.


Closes #67


Remaining Question: Do we also was to update the async client? If so, it would probably need more work since it has not been kept updated like the other.