### PR TITLE
Refactor Part I: Deprecate & Rename Old Routes

### DIFF
--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -170,14 +170,14 @@ class DuneClient(BaseDuneClient):  # pylint: disable=too-many-public-methods
         fetches and returns the results.
         Sleeps `ping_frequency` seconds between each status request.
         """
-        job_id = self.execute(query=query, performance=performance).execution_id
-        status = self.get_status(job_id)
+        job_id = self.execute_query(query=query, performance=performance).execution_id
+        status = self.get_execution_status(job_id)
         while status.state not in ExecutionState.terminal_states():
             self.logger.info(
                 f"waiting for query execution {job_id} to complete: {status}"
             )
             time.sleep(ping_frequency)
-            status = self.get_status(job_id)
+            status = self.get_execution_status(job_id)
         if status.state == ExecutionState.FAILED:
             self.logger.error(status)
             raise QueryFailed(f"{status}. Perhaps your query took too long to run!")
@@ -429,7 +429,7 @@ class DuneClient(BaseDuneClient):  # pylint: disable=too-many-public-methods
         job_id = self._refresh(
             query, ping_frequency=ping_frequency, performance=performance
         )
-        return self.get_result(job_id)
+        return self.get_execution_results(job_id)
 
     def run_query_csv(
         self,
@@ -445,7 +445,7 @@ class DuneClient(BaseDuneClient):  # pylint: disable=too-many-public-methods
         job_id = self._refresh(
             query, ping_frequency=ping_frequency, performance=performance
         )
-        return self.get_result_csv(job_id)
+        return self.get_execution_results_csv(job_id)
 
     def run_query_dataframe(
         self, query: QueryBase, performance: Optional[str] = None
@@ -462,5 +462,5 @@ class DuneClient(BaseDuneClient):  # pylint: disable=too-many-public-methods
             raise ImportError(
                 "dependency failure, pandas is required but missing"
             ) from exc
-        data = self.refresh_csv(query, performance=performance).data
+        data = self.run_query_csv(query, performance=performance).data
         return pandas.read_csv(data)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,3 +5,5 @@ types-requests>=2.31.0.2
 python-dateutil>=2.8.2
 requests>=2.31.0
 ndjson>=0.3.1
+Deprecated>=1.2.14
+types-Deprecated==1.2.9.3


### PR DESCRIPTION
the functions touched here are:

- refresh --> run_query
- refresh_csv --> run_query_csv
- refresh_into_data_frame --> run_query_dataframe
- get_status --> get_execution_status
- execute --> execute_query
- get_result --> get_execution_results

Maybe a couple others I forgot.

We had to temporarily add a pylint: ignore `too-many-public-methods` but this will be lifted when we split the client into 

`DuneExecutionsAPI, DuneQueryAPI, DuneUploadAP` - See #72 


cc @TheEdgeOfRage & @diegoximenes for additional review.

