### PR TITLE
[Easy] Cleanup

### DIFF
--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -364,7 +364,6 @@ class DuneClient(DuneInterface, BaseDuneClient):
     def make_private(self, query_id: int) -> None:
         """
         https://dune.com/docs/api/api-reference/edit-queries/private-query
-        returns resulting value of Query.is_private
         """
         response_json = self._post(route=f"/query/{query_id}/private")
         assert self.get_query(int(response_json["query_id"])).meta.is_private
@@ -372,7 +371,6 @@ class DuneClient(DuneInterface, BaseDuneClient):
     def make_public(self, query_id: int) -> None:
         """
         https://dune.com/docs/api/api-reference/edit-queries/private-query
-        returns resulting value of Query.is_private
         """
         response_json = self._post(route=f"/query/{query_id}/unprivate")
         assert not self.get_query(int(response_json["query_id"])).meta.is_private

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -176,6 +176,7 @@ class TestDuneClient(unittest.TestCase):
         self.assertGreater(len(results), 0)
 
 
+@unittest.skip("This is an enterprise only endpoint that can no longer be tested.")
 class TestCRUDOps(unittest.TestCase):
     def setUp(self) -> None:
         dotenv.load_dotenv()

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -151,7 +151,7 @@ class TestDuneClient(unittest.TestCase):
             dune.execute(query)
         self.assertEqual(
             str(err.exception),
-            "Can't build ExecutionResponse from {'error': 'Query not found'}",
+            "Can't build ExecutionResponse from {'error': 'An internal error occured'}",
         )
 
     def test_invalid_job_id_error(self):


### PR DESCRIPTION
Some things that had to be fixed before we proceed with bigger changes

- skip CURD tests because the alpha endpoint doesn't exist anymore.
- Remove incorrect content in doc strings.
- Update Error message in test.