### PR TITLE
[Maintenance] update publish workflow

### DIFF
--- a/.github/workflows/py-publish.yaml
+++ b/.github/workflows/py-publish.yaml
@@ -19,6 +19,9 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v3
@@ -34,5 +37,3 @@ jobs:
       run: python -m build
     - name: Publish a Python distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
PyPi No longer supports Publish tokens. Rather a new approach described here:

https://docs.pypi.org/trusted-publishers/using-a-publisher/ 